### PR TITLE
fix: GlobalExceptionHandler ErrorResponse 오류

### DIFF
--- a/src/main/java/com/example/jeogiyoproject/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/jeogiyoproject/global/exception/ErrorResponse.java
@@ -1,8 +1,10 @@
 package com.example.jeogiyoproject.global.exception;
 
 import lombok.Builder;
+import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 
+@Getter
 @Builder
 public class ErrorResponse {
     private String status;


### PR DESCRIPTION
* `@Getter` 누락으로 ResponseEntity 리턴 시 오류 발생

`원인`: Spring의 ResponseEntity<T>는 기본적으로 JSON 형식으로 응답 본문(Response Body)을 변환한다.
Spring은 Jackson(ObjectMapper)을 사용하여 객체를 JSON으로 직렬화(Serialization)할 때, 필드 값을 가져오기 위해 getter 메서드를 필요로 한다.